### PR TITLE
Binsearch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
             content: name.to_string(),
             uuid: Uuid::new_v4(),
         })
-    .collect();
+        .collect();
 
     // set up shards and store
     for shard_no in 0..min_shards {
@@ -198,7 +198,6 @@ fn main() {
     // the "log" of all the docs that must move, keyed by id
     let mut moving = HashMap::new();
 
-    // FIXME: beyond tiny data, bad; doing (shards*labels)*docs
     // collecting all the moves into a "log" that could be read off
     for (origin_shard_info, documents) in shards_view.iter() {
         for document in documents.borrow().iter() {
@@ -209,21 +208,17 @@ fn main() {
             let mut last = shards_view.len();
 
             while first < last {
-                let pivot = (first+last)/2;
+                let pivot = (first + last) / 2;
                 if document.conhash_id == shard_keys[pivot].shard_key {
                     break;
                 } else if pivot > 0 && document.conhash_id < shard_keys[pivot].shard_key {
-                    if  document.conhash_id > shard_keys[pivot - 1].shard_key {
+                    // NOTE: we just want closest "under" so no matching branch
+                    if document.conhash_id > shard_keys[pivot - 1].shard_key {
                         assign_to = shard_keys[pivot - 1];
                         break;
                     }
                     last = pivot - 1;
                 } else {
-                    // if (mid < n - 1 and target < arr[mid + 1]):
-                    if pivot < shards_view.len() - 1 && document.conhash_id < shard_keys[pivot + 1].shard_key {
-                        break;
-                    }
-
                     first = pivot + 1;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,7 @@ fn main() {
 
     // immutable borrow to "view" the keys
     let shards_view = shard_mapping.clone();
+    let shard_keys = shards_view.keys().collect::<Vec<_>>();
 
     // the "log" of all the docs that must move, keyed by id
     let mut moving = HashMap::new();
@@ -207,7 +208,6 @@ fn main() {
             let mut first = 0;
             let mut last = shards_view.len();
 
-            let shard_keys = shards_view.keys().collect::<Vec<_>>();
             while first < last {
                 let pivot = (first+last)/2;
                 if document.conhash_id == shard_keys[pivot].shard_key {


### PR DESCRIPTION
Switching from linear scan up to max below target (I assume this is correct, but slow) to binary search. Speed up from ~10s to ~200ms.

Don't really have test cases proving this out. Seems like the binsearch might be producing less data moves compared to base linear but it can produce moves above expected count. So could just be variance.